### PR TITLE
fix url is not defined

### DIFF
--- a/dmax_dl/__init__.py
+++ b/dmax_dl/__init__.py
@@ -29,7 +29,7 @@ def main():
     )
     args = parser.parse_args()
 
-    episodes = scraper().parse(url)
+    episodes = scraper().parse(args.series_url)
     s = series(args.series_url)
     s.add(episodes)
     dlmgr = mgr(s, args.output_dir, args.format)


### PR DESCRIPTION
This fixes the following error:
```
Traceback (most recent call last):
  File "/home/user/git/dmax_dl.py/dmax_dl/__init__.py", line 40, in <module>
    main()
  File "/home/user/git/dmax_dl.py/dmax_dl/__init__.py", line 32, in main
    episodes = scraper().parse(url)
NameError: name 'url' is not defined
```